### PR TITLE
Add CiteURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [Haystack - Transformers at scale for question answering & neural search](https://github.com/deepset-ai/haystack)
 - [Sentence Boundary Detection (US Caselaw)](https://github.com/jsavelka/luima_sbd)
 - [Quantitative Legal Studies](https://github.com/QuantLaw)
+- [CiteURL - an extensible tool to detect and hyperlink legal citations](https://github.com/raindrum/citeurl/)
 
 ## Datasets and Data
 [Back to Top](#contents)


### PR DESCRIPTION
It's a library I recently wrote that uses citation templates written in YAML to detect citations and create hyperlinks to web pages where people can read the cited materials. By default, it supports most U.S. court cases (via the Caselaw Access Project), plus the U.S. Code and most codified state laws, as well as the U.S. Constitution and every state constitution, among other sources.