### PR TITLE
Adding the Kira M&A Due Diligence Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - International Law: [Text of Trade Agreements (ToTA)](https://github.com/mappingtreaties/tota/tree/master/xml), [Electronic Database on Investment Treaties (EDIT)](https://edit.wti.org/document/investment-treaty/search)
 - United Nations: [United Nations General Debate Corpus](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/0TJX8Y), [United Nations Parallel Corpus](https://conferences.unite.un.org/uncorpus)
 - [Contract Understanding Atticus Dataset](https://www.atticusprojectai.org/cuad) by [The Atticus Project](https://www.atticusprojectai.org/): A corpus of 13,000+ labels in 510 commercial legal contracts with rich expert annotations.
+- [Kira Systems M&A Dataset](https://kirasystems.com/science/dataset-and-examination-of-passages-for-due-diligence/) by [Kira Systems](https://kirasystems.com/): A non-commercial use dataset comprising 4,400 documents and labels for 50 legal concepts in the M&A Due Diligence setting.
 
 
 ## Annotation and Data Schemes


### PR DESCRIPTION
Adding the Kira Systems M&A Due Diligence dataset comprising 4,400 documents from EDGAR and CEDAR with labels for 50 legal concepts.